### PR TITLE
Only default the selection for movement attempts

### DIFF
--- a/src/app/keyboard.ts
+++ b/src/app/keyboard.ts
@@ -31,10 +31,14 @@ export const handleKeyboardInput = (
   }
 
   if (!uiSelection) {
-    selectTaskTimeSegment({
-      taskId: tasksForDate[0],
-      timeSegment: 0,
-    });
+    const movementAttempted = ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(event.key);
+    if (movementAttempted) {
+      selectTaskTimeSegment({
+        taskId: tasksForDate[0],
+        timeSegment: 0,
+      });
+    }
+
     return;
   }
 

--- a/src/app/keyboard.ts
+++ b/src/app/keyboard.ts
@@ -31,7 +31,13 @@ export const handleKeyboardInput = (
   }
 
   if (!uiSelection) {
-    const movementAttempted = ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(event.key);
+    const movementAttempted = [
+      'ArrowUp',
+      'ArrowDown',
+      'ArrowLeft',
+      'ArrowRight',
+    ].includes(event.key);
+
     if (movementAttempted) {
       selectTaskTimeSegment({
         taskId: tasksForDate[0],


### PR DESCRIPTION
When creating a task via enter key, a phantom time assignment was made without the task ID due to a selection bug. Avoid defaulting the selection unless the user is attempting an arrow movement.